### PR TITLE
from-notion-rich-text-item.tsではstrikethroughをサポートしているのでto-notion-blocks.tsでもサポートします。

### DIFF
--- a/lib/to-notion-block/to-notion-blocks.ts
+++ b/lib/to-notion-block/to-notion-blocks.ts
@@ -292,6 +292,18 @@ function parseInlineToken(token: Tokens.Generic): CustomRichTextItem {
     }
   }
 
+  if (token.type === "del") {
+    return {
+      type: "text",
+      text: {
+        content: token.text,
+      },
+      annotations: {
+        strikethrough: true,
+      },
+    }
+  }
+
   return {
     type: "text",
     text: {

--- a/lib/types/custom-rich-text-item.ts
+++ b/lib/types/custom-rich-text-item.ts
@@ -7,5 +7,6 @@ export type CustomRichTextItem = {
     bold?: boolean
     italic?: boolean
     code?: boolean
+    strikethrough?: boolean
   }
 }


### PR DESCRIPTION
lib/utils/from-notion-rich-text-item.tsではstrikethroughをサポートしているのでto-notion-blocksでもサポートするように変更

該当箇所
https://github.com/RyukyuInteractive/open-notion/blob/966ae2a2131ad85866cadb1702b2f291823b678b/lib/utils/from-notion-rich-text-item.ts#L21